### PR TITLE
Add note to 202012-1 around possible cert incompatibility

### DIFF
--- a/v202012-1.md
+++ b/v202012-1.md
@@ -4,6 +4,7 @@
 APPLICATION LEVEL BREAKING CHANGES:
 
 1. Renamed the `replicated admin` alias from `ptfe-admin` to `tfe-admin` to better match the product name.
+1. Some services have been upgraded to Go 1.15 which can cause issues with certificates still using the deprecated Common Name (CN) field and do not have a Subject Alternative Names (SAN) field.
 
 APPLICATION LEVEL FEATURES:
 


### PR DESCRIPTION
Go 1.15 changed support for certs using the deprecated CN field and no SAN field. This is calling it out as a possible issue as some folks may still be on this setup and need to generate a new certificate with the SAN set to upgrade. 