### PR TITLE
Remove link to private repo.

### DIFF
--- a/v202104-1.md
+++ b/v202104-1.md
@@ -10,7 +10,7 @@ APPLICATION LEVEL FEATURES:
 
 1. Added policy check events to the audit log and audit trail APIs.
 1. Added ability to define working directory while changing a workspace's VCS source
-1. Changed the Sentinel runtime to version 0.18.0. For the latest changes, see the [release notes](https://docs.hashicorp.com/sentinel/changelog). [hashicorp/tfe-sentinel-worker#126](https://github.com/hashicorp/tfe-sentinel-worker/pull/126)
+1. Changed the Sentinel runtime to version 0.18.0. For the latest changes, see the [release notes](https://docs.hashicorp.com/sentinel/changelog). 
 1. Changed Modules page to be Registry and updated urls
 1. Added Terraform CLI versions up through 0.15.0 to Terraform Enterprise.
 1. Added the ability to restrict state access (usually performed via the `terraform_remote_state` data source) to specific workspaces within an organization, along with an admin setting to configure the default setting for new workspaces and a command line migration assistant.


### PR DESCRIPTION
There was a link included to the sentinel repo, which is private and inaccessible for customers; it has been removed. 