### PR TITLE
Remove private repository links

### DIFF
--- a/v202103-1.md
+++ b/v202103-1.md
@@ -65,7 +65,7 @@ APPLICATION LEVEL BUG FIXES:
 1. Fixed a potential issue where some cost estimates might be off by 1-2%
 1. Fixed the user invitation modal list of teams, ensuring teams are correctly paginated to include all of them.
 1. Fixed an issue where working directories were having their leading and trailing slashes stripped during updating.
-1. Fixed Modules ingress for Bitbucket Webhook events containing multiple changes.-- **@nicsnet** [hashicorp/atlas#10299](https://github.com/hashicorp/atlas/pull/10299)
+1. Fixed Modules ingress for Bitbucket Webhook events containing multiple changes.
 1. Fixed an issue where custom CA certificates were not being passed to the `telegraf` container.
 1. Fixed API issue where includable resource parameters were required to be underscored, even as the API is generally hyphenated.
 1. Fixed workspace variables API to require the correct workspace in URL

--- a/v202103-2.md
+++ b/v202103-2.md
@@ -68,7 +68,7 @@ APPLICATION LEVEL BUG FIXES:
 1. Fixed a potential issue where some cost estimates might be off by 1-2%
 1. Fixed the user invitation modal list of teams, ensuring teams are correctly paginated to include all of them.
 1. Fixed an issue where working directories were having their leading and trailing slashes stripped during updating.
-1. Fixed Modules ingress for Bitbucket Webhook events containing multiple changes.-- **@nicsnet** [hashicorp/atlas#10299](https://github.com/hashicorp/atlas/pull/10299)
+1. Fixed Modules ingress for Bitbucket Webhook events containing multiple changes.
 1. Fixed an issue where custom CA certificates were not being passed to the `telegraf` container.
 1. Fixed API issue where includable resource parameters were required to be underscored, even as the API is generally hyphenated.
 1. Fixed workspace variables API to require the correct workspace in URL

--- a/v202103-3.md
+++ b/v202103-3.md
@@ -72,7 +72,7 @@ APPLICATION LEVEL BUG FIXES:
 1. Fixed a potential issue where some cost estimates might be off by 1-2%
 1. Fixed the user invitation modal list of teams, ensuring teams are correctly paginated to include all of them.
 1. Fixed an issue where working directories were having their leading and trailing slashes stripped during updating.
-1. Fixed Modules ingress for Bitbucket Webhook events containing multiple changes.-- **@nicsnet** [hashicorp/atlas#10299](https://github.com/hashicorp/atlas/pull/10299)
+1. Fixed Modules ingress for Bitbucket Webhook events containing multiple changes.
 1. Fixed an issue where custom CA certificates were not being passed to the `telegraf` container.
 1. Fixed API issue where includable resource parameters were required to be underscored, even as the API is generally hyphenated.
 1. Fixed workspace variables API to require the correct workspace in URL

--- a/v202105-1.md
+++ b/v202105-1.md
@@ -14,8 +14,8 @@ APPLICATION LEVEL FEATURES:
 1. Changed submodule and examples UI
 1. Added Terraform CLI versions up through 0.15.3 to Terraform Enterprise.
 1. Changed the maximum Sentinel job execution time to 1 hour.
-1. Changed the Sentinel runtime to version 0.18.1. For the latest changes, see the [release notes](https://docs.hashicorp.com/sentinel/changelog). --  **@vancluever** [hashicorp/tfe-sentinel-worker#131](https://github.com/hashicorp/tfe-sentinel-worker/pull/131)
-1. Changed mock generation so that: 1) best efforts are made to obfuscate sensitive values, and 2) generate the sample configuration file as HCL instead of legacy JSON. --  **@vancluever** [hashicorp/tfe-plan-export-worker#63](https://github.com/hashicorp/tfe-plan-export-worker/pull/63)
+1. Changed the Sentinel runtime to version 0.18.1. For the latest changes, see the [release notes](https://docs.hashicorp.com/sentinel/changelog).
+1. Changed mock generation so that: 1) best efforts are made to obfuscate sensitive values, and 2) generate the sample configuration file as HCL instead of legacy JSON.
 
 APPLICATION LEVEL BUG FIXES:
 


### PR DESCRIPTION
There was a link included to the atlas repo, which is private and inaccessible for customers; it has been removed.