### PR TITLE
Remove note that's not applicable to TFE

### DIFF
--- a/v202106-1.md
+++ b/v202106-1.md
@@ -9,7 +9,6 @@ APPLICATION LEVEL FEATURES:
 
 1. Added support for several new capabilities in remote runs triggered via the CLI and API: `-refresh=false`, `-refresh-only`, and `-replace=ADDRESS`. See [the documentation](https://www.terraform.io/docs/cloud/run/modes-and-options.html) for more details on each of these options.
 1. Added Terraform CLI versions up through 0.15.5 to Terraform Enterprise.
-1. Added the ability to destroy agents via the API.
 1. Changed Terraform Cost Estimation to use the new, free Azure pricing API. This changes the [Azure egress hostname](https://www.terraform.io/docs/enterprise/before-installing/network-requirements.html#prices-azure-com) to `prices.azure.com`.
 1. Updated the UX for the Registry
 1. Changed the Sentinel runtime to version 0.18.3. For the latest changes, see the [release notes](https://docs.hashicorp.com/sentinel/changelog).


### PR DESCRIPTION
The note `Added the ability to destroy agents via the API.` is not actually applicable to TFE, removing.