### PR TITLE
adds message about the audit log bug to TFE v202205-1 release

### DIFF
--- a/v202205-1.md
+++ b/v202205-1.md
@@ -3,7 +3,7 @@
 
 APPLICATION LEVEL BREAKING CHANGES:
 
-1. All container names now follow the same naming convention: "tfe-<service>". If you have tooling that identifies containers by name, make sure this tooling is updated to reflect the new naming convention.
+1. All container names now follow the same naming convention: `tfe-<service>`. If you have tooling that identifies containers by name, make sure this tooling is updated to reflect the new naming convention.
 
 
 APPLICATION LEVEL FEATURES:
@@ -23,6 +23,7 @@ APPLICATION LEVEL BUG FIXES:
 8. Fixed a bug that caused Git operations to retry unrecoverable authentication errors.
 9. Improved agent dequeueing performance for large agent pools.
 10. Changed Vault CLI commands to Vault API calls for token creation. This will prevent any Vault CLI/Server version mismatch errors.
+11. Fixed issue where log tags such as `[Audit Log]` were not visible in logs.
 
 
 APPLICATION LEVEL SECURITY FIXES:


### PR DESCRIPTION
What
An additional change to the release notes from this PR: https://github.com/hashicorp/atlas/pull/12343.

Why
The backport did not get captured into the release notes changelog since it was included after the changelog PR was generated.