### PR TITLE
add back migration release note

### DIFF
--- a/v202206-1.md
+++ b/v202206-1.md
@@ -14,6 +14,7 @@ APPLICATION LEVEL FEATURES:
 1. Updated the email template used when sending VCS notifications.
 1. Added support for [sending notifications to Microsoft Teams channels](https://www.terraform.io/cloud-docs/workspaces/settings/notifications#microsoft-teams)
 1. Terraform CLI versions up through 1.2.1 are now available.
+1. Added a background task to backfill the `plan_only` column on the runs table. This is an internal cleanup task to support ongoing app improvements. No action is required. A future TFE release will perform any remaining work for this backfill as a normal database migration during the upgrade.
 
 APPLICATION LEVEL BUG FIXES:
 


### PR DESCRIPTION
A release note about background migrations was mistakenly left off the release notes.