### PR TITLE
Remove deprecation references to RHEL/CentOS 7

### DIFF
--- a/v202210-1.md
+++ b/v202210-1.md
@@ -6,8 +6,6 @@ The following operating systems are deprecated and are no longer supported.
 
 - Debian 8, 9
 - Ubuntu 14.04, 16.04
-- Red Hat Enterprise Linux (RHEL) 7
-- CentOS 7
 - Amazon Linux 2014.03, 2014.09, 2015.03, 2015.09, 2016.03, 2016.09, 2017.03, 2017.09, 2018.03
 
 PostgreSQL server version 10 is deprecated and is no longer supported.


### PR DESCRIPTION
Deprecation of RHEL/Cent OS 7 was done accidentally. Proposing we delete reference to RHEL/CentOS deprecation.