### PR TITLE
Mark repository as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,5 @@
 # Terraform Enterprise Release Notes
 
-This repository contains the release notes for Terraform Enterprise and is updated automatically upon each release. More information about Terraform Enterprise can be found on [terraform.io](https://www.terraform.io/docs/enterprise/).
-
-Questions or Issues related to Terraform Enterprise can be directed to [support](https://support.hashicorp.com), your Technical Account Manager or your Sales Executive.
-
-## Updating Release Notes (internal use only)
-
-Because of the inability to overwrite files in this repository (see workflows in
-`.circleci/config.yaml` for PTFE Releases ), updating release notes is a manual
-process. To update any release notes in this repository after they've been
-published, [submit a pull request][gh-new-pr] with the changes that need to be made.
-
-[gh-new-pr]: https://github.com/hashicorp/terraform-enterprise-release-notes/compare "Submit new PR in this repository"
+This repository will be archived on December 31, 2022. The release notes for
+Terraform Enterprise are now located on
+[developer.hashicorp.com](https://developer.hashicorp.com/terraform/enterprise/releases).


### PR DESCRIPTION
The release notes are now on the public website. This repository is no longer needed.
