### PR TITLE
fix: update minimum version for PostgreSQL

### DIFF
--- a/v202210-1.md
+++ b/v202210-1.md
@@ -6,7 +6,7 @@ Last required release: [v202207-2 (642)](https://developer.hashicorp.com/terrafo
 
 ### Breaking Changes
 
-PostgreSQL server version 10 is no longer supported. If you are using an external PostgreSQL server with your Terraform Enterprise installation, you must upgrade to PostgreSQL server version 11 or later.
+PostgreSQL server version 10 is no longer supported. If you are using an external PostgreSQL server with your Terraform Enterprise installation, you must upgrade to PostgreSQL server version 11 or later. However, we recommend upgrading to PostgreSQL server version 12 or later instead of PostgreSQL server version 11 since PostgreSQL server version 11 is deprecated.
 
 ### Deprecation Notices
 

--- a/v202210-1.md
+++ b/v202210-1.md
@@ -6,7 +6,7 @@ Last required release: [v202207-2 (642)](https://developer.hashicorp.com/terrafo
 
 ### Breaking Changes
 
-PostgreSQL server version 10 is no longer supported. If you are using an external PostgreSQL server with your Terraform Enterprise installation, you must upgrade to PostgreSQL server version 12 or later.
+PostgreSQL server version 10 is no longer supported. If you are using an external PostgreSQL server with your Terraform Enterprise installation, you must upgrade to PostgreSQL server version 11 or later.
 
 ### Deprecation Notices
 


### PR DESCRIPTION
Should minimum version for external PostgreSQL server version be `v11`?